### PR TITLE
feat: integrate FSRS backend with frontend

### DIFF
--- a/src/components/pomodoro/PomodoroContent.tsx
+++ b/src/components/pomodoro/PomodoroContent.tsx
@@ -2,7 +2,8 @@
 
 import { useCallback, useEffect, useState } from 'react';
 import { getAppShellViewportInsets } from '@/lib/app-shell';
-import { getFlashcardDeck } from '@/lib/frontend-store';
+import { fsrsClient } from '@/lib/fsrs-client';
+import type { DeckWithStats } from '@/hooks/useDecks';
 import {
   AddFlashcardsWidget,
   CameraWidget,
@@ -55,47 +56,43 @@ export function PomodoroContent({
 
   // Payload for editing an existing deck
   const [editPayload, setEditPayload] = useState<{
-    fcID: number;
+    apiDeckId: number;
     deckTitle: string;
     description?: string;
-    flashcards?: { question: string; answer: string; id?: string }[];
+    flashcards?: {
+      question: string;
+      answer: string;
+      id?: string;
+      backendId?: number;
+    }[];
   } | null>(null);
 
   // Open the AddFlashcardsWidget in edit mode for a given deck
-  const openEditDeck = async (deck: {
-    fc_id: number;
-    fc_name: string;
-    description?: string;
-  }) => {
+  const openEditDeck = async (deck: DeckWithStats) => {
     try {
-      const storedDeck = getFlashcardDeck(deck.fc_id);
-      if (!storedDeck) {
-        throw new Error('Failed to fetch deck questions');
-      }
-
-      const flashcards = storedDeck.questions.map((q) => ({
-        question: q.question,
-        answer: q.answer,
-        id: `${q.qID}`,
+      const cards = await fsrsClient.cards.list(deck.id);
+      const flashcards = cards.map((c) => ({
+        question: c.front,
+        answer: c.back,
+        id: `${c.id}`,
+        backendId: c.id,
       }));
 
       setEditPayload({
-        fcID: deck.fc_id,
-        deckTitle: deck.fc_name,
-        description: deck.description,
+        apiDeckId: deck.id,
+        deckTitle: deck.name,
+        description: deck.description ?? undefined,
         flashcards,
       });
 
-      // Open widget
       setWidgets((prev) => ({ ...prev, addFlashcards: { isOpen: true } }));
       setActiveWidget('addFlashcards');
     } catch (err) {
       console.error('Failed to open edit deck:', err);
-      // fallback: open widget empty
       setEditPayload({
-        fcID: deck.fc_id,
-        deckTitle: deck.fc_name,
-        description: deck.description,
+        apiDeckId: deck.id,
+        deckTitle: deck.name,
+        description: deck.description ?? undefined,
       });
       setWidgets((prev) => ({ ...prev, addFlashcards: { isOpen: true } }));
       setActiveWidget('addFlashcards');
@@ -272,7 +269,7 @@ export function PomodoroContent({
           initialDeck={
             editPayload
               ? {
-                  fcID: editPayload.fcID,
+                  apiDeckId: editPayload.apiDeckId,
                   deckTitle: editPayload.deckTitle,
                   description: editPayload.description,
                 }

--- a/src/components/pomodoro/widgets/AddFlashcardsWidget.tsx
+++ b/src/components/pomodoro/widgets/AddFlashcardsWidget.tsx
@@ -7,11 +7,13 @@ import { Label } from '@/components/ui/label';
 import { Card } from '@/components/ui/card';
 import { X, Plus, Check } from 'lucide-react';
 import { createFlashcardDeck, updateFlashcardDeck } from '@/lib/frontend-store';
+import { fsrsClient } from '@/lib/fsrs-client';
 
 interface FlashcardEntry {
   question: string;
   answer: string;
   id?: string;
+  backendId?: number;
   source?: 'csv' | 'manual';
 }
 
@@ -20,7 +22,8 @@ interface AddFlashcardsWidgetProps {
   // If provided, widget becomes an editor for an existing deck
   edit?: boolean;
   initialDeck?: {
-    fcID: number;
+    fcID?: number;
+    apiDeckId?: number;
     deckTitle: string;
     description?: string;
   };
@@ -167,7 +170,6 @@ export function AddFlashcardsWidget(props: AddFlashcardsWidgetProps) {
   };
 
   const handleSubmit = async () => {
-    // Mark form as submitted to show field-level validation
     setSubmitted(true);
 
     if (!deckTitle.trim()) {
@@ -190,6 +192,52 @@ export function AddFlashcardsWidget(props: AddFlashcardsWidgetProps) {
     setError('');
 
     try {
+      const apiDeckId = props.initialDeck?.apiDeckId;
+
+      if (props.edit && apiDeckId) {
+        // API deck edit: update/add/delete cards via backend
+        const originalBackendIds = new Set(
+          (props.initialFlashcards ?? [])
+            .map((f) => f.backendId)
+            .filter((id): id is number => id !== undefined)
+        );
+        const currentBackendIds = new Set(
+          validCards
+            .map((c) => c.backendId)
+            .filter((id): id is number => id !== undefined)
+        );
+
+        // Delete removed cards
+        const deletedIds = [...originalBackendIds].filter(
+          (id) => !currentBackendIds.has(id)
+        );
+        await Promise.all(
+          deletedIds.map((cardId) => fsrsClient.cards.delete(apiDeckId, cardId))
+        );
+
+        // Update existing and add new cards sequentially
+        for (const card of validCards) {
+          if (card.backendId) {
+            await fsrsClient.cards.update(
+              apiDeckId,
+              card.backendId,
+              card.question.trim(),
+              card.answer.trim()
+            );
+          } else {
+            await fsrsClient.cards.add(
+              apiDeckId,
+              card.question.trim(),
+              card.answer.trim()
+            );
+          }
+        }
+
+        props.onSaved?.();
+        props.onClose();
+        return;
+      }
+
       if (props.edit && props.initialDeck?.fcID) {
         updateFlashcardDeck({
           fcID: props.initialDeck.fcID,
@@ -197,8 +245,6 @@ export function AddFlashcardsWidget(props: AddFlashcardsWidgetProps) {
           description: description.trim(),
           flashcards: validCards,
         });
-
-        // Notify parent and close
         props.onSaved?.();
         props.onClose();
         return;
@@ -210,7 +256,6 @@ export function AddFlashcardsWidget(props: AddFlashcardsWidgetProps) {
         flashcards: validCards,
       });
 
-      // Success - clear any validation timer and refresh the page to show new deck
       if (submittedTimeoutRef.current) {
         clearTimeout(submittedTimeoutRef.current);
         submittedTimeoutRef.current = null;
@@ -219,7 +264,7 @@ export function AddFlashcardsWidget(props: AddFlashcardsWidgetProps) {
       props.onClose();
     } catch (err) {
       setError(
-        err instanceof Error ? err.message : 'Failed to create flashcards'
+        err instanceof Error ? err.message : 'Failed to save flashcards'
       );
     } finally {
       setIsSubmitting(false);

--- a/src/components/pomodoro/widgets/FlashcardPracticeArea.tsx
+++ b/src/components/pomodoro/widgets/FlashcardPracticeArea.tsx
@@ -11,223 +11,107 @@ import {
 } from '@/components/ui/dropdown-menu';
 import { Loader2, Layers, Clock, ArrowLeft } from 'lucide-react';
 import { cn } from '@/lib/utils';
-import {
-  CardState,
-  Difficulty,
-  getDueCards,
-  areAllCardsMastered,
-} from '@/components/pomodoro/spacedRepetition';
-import {
-  deleteFlashcardDeck as removeFlashcardDeck,
-  getFlashcardDeck,
-  getFlashcardDeckCardStates,
-  listFlashcardDecks,
-  resetFlashcardDeckProgress as resetStoredFlashcardDeckProgress,
-  updateFlashcardState,
-} from '@/lib/frontend-store';
-
-interface Question {
-  qID: number;
-  question: string;
-  answer: string;
-}
-
-interface FlashcardDeck {
-  fc_id: number;
-  fc_name: string;
-  description?: string;
-}
-
-interface DeckStats {
-  fc_id: number;
-  totalCards: number;
-  dueCards: number;
-  nextCardAt: number | null;
-}
+import type { Difficulty } from '@/components/pomodoro/spacedRepetition';
+import { useDecks, type DeckWithStats } from '@/hooks/useDecks';
+import { useSession } from '@/hooks/useSession';
 
 export function FlashcardPracticeArea({
   onRequestEditDeck,
   cardAnimationEnabled = true,
   shortcutsEnabled = true,
 }: {
-  onRequestEditDeck?: (deck: FlashcardDeck) => void;
+  onRequestEditDeck?: (deck: DeckWithStats) => void;
   cardAnimationEnabled?: boolean;
   shortcutsEnabled?: boolean;
 }) {
-  // Loading spinner component
+  const enableCardAnimation = cardAnimationEnabled !== false;
+
+  const {
+    decks,
+    isLoading: isLoadingDecks,
+    error: decksError,
+    fetchDecks,
+    deleteDeck: apiDeleteDeck,
+  } = useDecks();
+
+  const [selectedDeck, setSelectedDeck] = useState<DeckWithStats | null>(null);
+  const [showDeckPreview, setShowDeckPreview] = useState(false);
+  const [isFlipped, setIsFlipped] = useState(false);
+  const [confirmDeleteDeck, setConfirmDeleteDeck] =
+    useState<DeckWithStats | null>(null);
+  const [isDeleting, setIsDeleting] = useState(false);
+  const [sortBy, setSortBy] = useState<'name' | 'due' | 'progress'>('due');
+  const [dueCountAnimation, setDueCountAnimation] = useState<'subtract' | null>(
+    null
+  );
+
+  const {
+    currentCard,
+    totalCards,
+    dueCount,
+    isLoading: isLoadingSession,
+    isSubmitting,
+    error: sessionError,
+    sessionComplete,
+    noCardsDue,
+    loadSession,
+    submitReview,
+    nextDueAt,
+    resetSession,
+  } = useSession(selectedDeck?.id ?? null);
+
+  const error = decksError ?? sessionError;
+  const isLoadingDeck = isLoadingDecks || isLoadingSession;
+
   const LoadingSpinner = () => (
     <div className="flex items-center justify-center gap-3">
       <Loader2 className="h-6 w-6 animate-spin text-white" />
       <span className="text-lg text-white">Loading...</span>
     </div>
   );
-  const enableCardAnimation = cardAnimationEnabled !== false;
-  const [decks, setDecks] = useState<FlashcardDeck[]>([]);
-  const [deckStats, setDeckStats] = useState<Record<number, DeckStats>>({});
-  const [selectedDeck, setSelectedDeck] = useState<FlashcardDeck | null>(null);
-  const [showDeckPreview, setShowDeckPreview] = useState(false);
-  const [questions, setQuestions] = useState<Question[]>([]);
-  const [cardStates, setCardStates] = useState<CardState[]>([]);
-  const [currentQID, setCurrentQID] = useState<number | null>(null);
-  const [isFlipped, setIsFlipped] = useState(false);
-  const [allMastered, setAllMastered] = useState(false);
-  const [showMasteredMessage, setShowMasteredMessage] = useState(false);
-  const [isLoadingDeck, setIsLoadingDeck] = useState(true);
-  const [isResetting, setIsResetting] = useState(false);
-  const [now, setNow] = useState(0);
-  const [error, setError] = useState<string | null>(null);
-  const [dueCountAnimation, setDueCountAnimation] = useState<
-    'subtract' | 'add' | null
-  >(null);
-  const [sortBy, setSortBy] = useState<'name' | 'due' | 'progress'>('due');
 
-  // Update current time
-  useEffect(() => {
-    setNow(Date.now());
-    const interval = setInterval(() => setNow(Date.now()), 1000);
-    return () => clearInterval(interval);
-  }, []);
-
-  // Fetch decks on mount
   useEffect(() => {
     fetchDecks();
-  }, []);
+  }, [fetchDecks]);
 
-  const fetchDecks = async () => {
-    try {
-      setIsLoadingDeck(true);
-      setError(null);
-      const fetchedDecks = listFlashcardDecks();
-      setDecks(fetchedDecks);
-
-      // Fetch stats for each deck
-      const stats: Record<number, DeckStats> = {};
-      fetchedDecks.forEach((deck: FlashcardDeck) => {
-        const currentStates = getFlashcardDeckCardStates(deck.fc_id);
-        const dueCards = getDueCards(currentStates, Date.now());
-        const nextCard =
-          currentStates.length > 0
-            ? currentStates.reduce((min, card) =>
-                card.nextReviewAt < min.nextReviewAt ? card : min
-              )
-            : null;
-
-        stats[deck.fc_id] = {
-          fc_id: deck.fc_id,
-          totalCards: currentStates.length,
-          dueCards: dueCards.length,
-          nextCardAt: nextCard ? nextCard.nextReviewAt : null,
-        };
-      });
-      setDeckStats(stats);
-      setIsLoadingDeck(false);
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'An error occurred');
-      setIsLoadingDeck(false);
-    }
-  };
-
-  const selectDeck = async (deck: FlashcardDeck) => {
-    try {
-      setIsLoadingDeck(true);
-      setError(null);
-      setSelectedDeck(deck);
-
-      const storedDeck = getFlashcardDeck(deck.fc_id);
-      if (!storedDeck) {
-        throw new Error('Failed to fetch questions');
+  // Refresh deck stats when the user returns to the tab after being away
+  useEffect(() => {
+    const handleVisibility = () => {
+      if (document.visibilityState === 'visible' && !selectedDeck) {
+        fetchDecks();
       }
+    };
+    document.addEventListener('visibilitychange', handleVisibility);
+    return () =>
+      document.removeEventListener('visibilitychange', handleVisibility);
+  }, [fetchDecks, selectedDeck]);
 
-      const fetchedQuestions = storedDeck.questions.map((q) => ({
-        qID: q.qID,
-        question: q.question,
-        answer: q.answer,
-      }));
-      setQuestions(fetchedQuestions);
-
-      setCardStates(getFlashcardDeckCardStates(deck.fc_id));
-
-      setShowDeckPreview(true);
-      setIsLoadingDeck(false);
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'An error occurred');
-      setIsLoadingDeck(false);
+  // When no cards are due, auto-reload the session the moment the next card becomes due
+  useEffect(() => {
+    if (!noCardsDue) return;
+    const next = nextDueAt();
+    if (!next) return;
+    const delay = next.getTime() - Date.now();
+    if (delay <= 0) {
+      loadSession();
+      return;
     }
+    const timer = setTimeout(loadSession, delay);
+    return () => clearTimeout(timer);
+  }, [noCardsDue, nextDueAt, loadSession]);
+
+  const selectDeck = (deck: DeckWithStats) => {
+    resetSession();
+    setSelectedDeck(deck);
+    setShowDeckPreview(true);
+    setIsFlipped(false);
   };
 
   const startDeckPractice = () => {
     setShowDeckPreview(false);
-
-    // Set first card
-    const dueCards = getDueCards(cardStates, Date.now());
-    if (dueCards.length > 0) {
-      setCurrentQID(dueCards[0].qID);
-    } else if (cardStates.length > 0) {
-      const soonest = cardStates.reduce((min: CardState, card: CardState) =>
-        card.nextReviewAt < min.nextReviewAt ? card : min
-      );
-      setCurrentQID(soonest.qID);
-    }
+    setIsFlipped(false);
+    loadSession();
   };
-
-  const resetDeckProgress = async () => {
-    if (!selectedDeck) return;
-    try {
-      setIsResetting(true);
-      setError(null);
-      resetStoredFlashcardDeckProgress(selectedDeck.fc_id);
-      setCardStates(getFlashcardDeckCardStates(selectedDeck.fc_id));
-      setIsResetting(false);
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to reset deck');
-      setIsResetting(false);
-    }
-  };
-
-  const [confirmDeleteDeck, setConfirmDeleteDeck] =
-    useState<FlashcardDeck | null>(null);
-  const [isDeleting, setIsDeleting] = useState(false);
-
-  const deleteDeck = async (deck: FlashcardDeck) => {
-    // Open confirmation UI instead of window.confirm
-    setConfirmDeleteDeck(deck);
-  };
-
-  const performDeleteDeck = async (deck: FlashcardDeck) => {
-    try {
-      setIsDeleting(true);
-      setError(null);
-      removeFlashcardDeck(deck.fc_id);
-
-      // If the deleted deck is currently selected, clear selection
-      if (selectedDeck?.fc_id === deck.fc_id) {
-        setSelectedDeck(null);
-        setShowDeckPreview(false);
-        setQuestions([]);
-        setCardStates([]);
-      }
-
-      // Refresh deck list/stats
-      await fetchDecks();
-      setConfirmDeleteDeck(null);
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to delete deck');
-    } finally {
-      setIsDeleting(false);
-    }
-  };
-
-  // Get current card state
-  const currentCardState = cardStates.find((cs) => cs.qID === currentQID);
-  const currentQuestion = questions.find((q) => q.qID === currentQID);
-  const dueCards = getDueCards(cardStates, now);
-
-  // Check if all mastered
-  useEffect(() => {
-    if (cardStates.length === 0) return;
-    const mastered = areAllCardsMastered(cardStates, now);
-    setAllMastered(mastered);
-  }, [cardStates, now]);
 
   const handleFlip = useCallback(() => {
     setIsFlipped((f) => !f);
@@ -235,90 +119,68 @@ export function FlashcardPracticeArea({
 
   const handleDifficulty = useCallback(
     async (difficulty: Difficulty) => {
-      if (!currentCardState) return;
+      if (!currentCard || isSubmitting) return;
 
-      // Show subtract animation
       setDueCountAnimation('subtract');
       await new Promise((resolve) => setTimeout(resolve, 300));
+      setDueCountAnimation(null);
 
-      try {
-        const nextState = updateFlashcardState(
-          currentCardState.qID,
-          difficulty
-        );
-
-        // Update local state
-        const newCardStates = cardStates.map((cs) =>
-          cs.qID === currentCardState.qID ? nextState : cs
-        );
-        setCardStates(newCardStates);
-        setIsFlipped(false);
-
-        // Show add animation if card becomes due again
-        const wasDue = currentCardState.nextReviewAt <= now;
-        const isDueNow = nextState.nextReviewAt <= Date.now();
-        if (isDueNow && wasDue) {
-          setDueCountAnimation('add');
-          await new Promise((resolve) => setTimeout(resolve, 300));
-        }
-        setDueCountAnimation(null);
-
-        // Move to next due card
-        const updatedDueCards = getDueCards(newCardStates, now);
-        if (updatedDueCards.length > 0) {
-          const nextCard =
-            updatedDueCards.find((card) => card.qID !== currentCardState.qID) ||
-            updatedDueCards[0];
-          setCurrentQID(nextCard.qID);
-          setShowMasteredMessage(false);
-        } else {
-          // All current due cards answered
-          setShowMasteredMessage(true);
-          const soonest = newCardStates.reduce(
-            (min: CardState, card: CardState) =>
-              card.nextReviewAt < min.nextReviewAt ? card : min
-          );
-          setCurrentQID(soonest.qID);
-        }
-      } catch (err) {
-        setError(err instanceof Error ? err.message : 'Failed to update card');
-      }
+      setIsFlipped(false);
+      await submitReview(difficulty);
     },
-    [cardStates, currentCardState, now]
+    [currentCard, isSubmitting, submitReview]
   );
 
-  useEffect(() => {
-    if (!shortcutsEnabled) {
-      return;
+  const handleOptionalStop = () => {
+    setSelectedDeck(null);
+    setShowDeckPreview(false);
+    setIsFlipped(false);
+    resetSession();
+    fetchDecks();
+  };
+
+  const deleteDeck = (deck: DeckWithStats) => {
+    setConfirmDeleteDeck(deck);
+  };
+
+  const performDeleteDeck = async (deck: DeckWithStats) => {
+    try {
+      setIsDeleting(true);
+      await apiDeleteDeck(deck.id);
+      if (selectedDeck?.id === deck.id) {
+        setSelectedDeck(null);
+        setShowDeckPreview(false);
+        resetSession();
+      }
+      setConfirmDeleteDeck(null);
+    } catch (err) {
+      console.error('Failed to delete deck', err);
+    } finally {
+      setIsDeleting(false);
     }
+  };
+
+  useEffect(() => {
+    if (!shortcutsEnabled) return;
 
     const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.defaultPrevented) {
-        return;
-      }
+      if (event.defaultPrevented) return;
 
       const target = event.target as HTMLElement | null;
       if (target) {
-        const tagName = target.tagName;
+        const tag = target.tagName;
         if (
-          tagName === 'INPUT' ||
-          tagName === 'TEXTAREA' ||
-          tagName === 'SELECT' ||
-          tagName === 'BUTTON' ||
+          tag === 'INPUT' ||
+          tag === 'TEXTAREA' ||
+          tag === 'SELECT' ||
+          tag === 'BUTTON' ||
           target.isContentEditable
         ) {
           return;
         }
       }
 
-      if (
-        !currentCardState ||
-        !currentQuestion ||
-        showDeckPreview ||
-        allMastered
-      ) {
-        return;
-      }
+      if (!currentCard || showDeckPreview || sessionComplete) return;
 
       if ((event.key === ' ' || event.key === 'Enter') && !isFlipped) {
         event.preventDefault();
@@ -326,9 +188,7 @@ export function FlashcardPracticeArea({
         return;
       }
 
-      if (!isFlipped) {
-        return;
-      }
+      if (!isFlipped) return;
 
       switch (event.key) {
         case '1':
@@ -347,8 +207,6 @@ export function FlashcardPracticeArea({
           event.preventDefault();
           void handleDifficulty('easy');
           break;
-        default:
-          break;
       }
     };
 
@@ -356,33 +214,17 @@ export function FlashcardPracticeArea({
     return () => window.removeEventListener('keydown', handleKeyDown);
   }, [
     shortcutsEnabled,
-    currentCardState,
-    currentQuestion,
+    currentCard,
     showDeckPreview,
-    allMastered,
+    sessionComplete,
     isFlipped,
     handleDifficulty,
     handleFlip,
   ]);
 
-  const handleOptionalStop = () => {
-    setSelectedDeck(null);
-    setQuestions([]);
-    setCardStates([]);
-    setCurrentQID(null);
-    setIsFlipped(false);
-    setAllMastered(false);
-    setShowMasteredMessage(false);
-    fetchDecks();
-  };
-
-  // Show deck preview screen after selection
+  // Deck preview screen
   if (selectedDeck && showDeckPreview) {
-    const dueCardsCount = cardStates.filter(
-      (card) => new Date(card.nextReviewAt).getTime() <= now
-    ).length;
-    const isComplete = areAllCardsMastered(cardStates, now);
-    const canStart = cardStates.length === 0 || !isComplete;
+    const stats = decks.find((d) => d.id === selectedDeck.id) ?? selectedDeck;
 
     return (
       <div className="flex w-full flex-1 items-center justify-center">
@@ -390,7 +232,7 @@ export function FlashcardPracticeArea({
           <div className="mb-8">
             <div className="mb-4 flex items-start justify-between">
               <h2 className="text-2xl font-bold text-white">
-                {selectedDeck.fc_name}
+                {selectedDeck.name}
               </h2>
               <button
                 onClick={handleOptionalStop}
@@ -405,55 +247,39 @@ export function FlashcardPracticeArea({
                 {selectedDeck.description}
               </p>
             )}
-            {cardStates.length > 0 && (
-              <div className="space-y-4">
-                <div className="flex gap-3">
-                  <div className="flex flex-1 items-center gap-3 rounded-lg border border-[#4a4a46] bg-[#191919] p-3">
-                    <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-[#4a4a46]">
-                      <Layers className="h-5 w-5 text-gray-300" />
-                    </div>
-                    <div>
-                      <p className="text-xs text-gray-400">Total Cards</p>
-                      <p className="text-xl font-semibold text-white">
-                        {cardStates.length}
-                      </p>
-                    </div>
-                  </div>
-                  <div className="flex flex-1 items-center gap-3 rounded-lg border border-[#4a4a46] bg-[#191919] p-3">
-                    <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-[#4a4a46]">
-                      <Clock className="h-5 w-5 text-gray-300" />
-                    </div>
-                    <div>
-                      <p className="text-xs text-gray-400">Due Now</p>
-                      <p className="text-xl font-semibold text-white">
-                        {dueCardsCount}
-                      </p>
-                    </div>
-                  </div>
+            <div className="flex gap-3">
+              <div className="flex flex-1 items-center gap-3 rounded-lg border border-[#4a4a46] bg-[#191919] p-3">
+                <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-[#4a4a46]">
+                  <Layers className="h-5 w-5 text-gray-300" />
                 </div>
-                {isComplete && (
-                  <p className="text-green-400">✓ All cards reviewed!</p>
-                )}
+                <div>
+                  <p className="text-xs text-gray-400">Total Cards</p>
+                  <p className="text-xl font-semibold text-white">
+                    {stats.totalCards}
+                  </p>
+                </div>
               </div>
-            )}
+              <div className="flex flex-1 items-center gap-3 rounded-lg border border-[#4a4a46] bg-[#191919] p-3">
+                <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-[#4a4a46]">
+                  <Clock className="h-5 w-5 text-gray-300" />
+                </div>
+                <div>
+                  <p className="text-xs text-gray-400">Due Now</p>
+                  <p className="text-xl font-semibold text-white">
+                    {stats.dueCards}
+                  </p>
+                </div>
+              </div>
+            </div>
           </div>
-          <div className="flex flex-wrap justify-between">
-            <Button
-              onClick={resetDeckProgress}
-              variant="ghost"
-              className="border border-[#4a4a46] bg-none px-4 py-2 text-sm font-normal text-white transition-colors hover:border-[#5a5a56] hover:bg-[#4a4a46] hover:text-white"
-              disabled={isResetting}
-            >
-              {isResetting ? 'Resetting...' : 'Reset Progress'}
-            </Button>
-
+          <div className="flex justify-end">
             <Button
               onClick={startDeckPractice}
-              disabled={!canStart}
+              disabled={stats.dueCards === 0}
               variant="default"
-              className={`px-8 py-2 text-sm ${!canStart ? 'cursor-not-allowed opacity-50' : ''}`}
+              className={`px-8 py-2 text-sm ${stats.dueCards === 0 ? 'cursor-not-allowed opacity-50' : ''}`}
             >
-              Start
+              {stats.dueCards === 0 ? 'No Cards Due' : 'Start'}
             </Button>
           </div>
         </div>
@@ -461,7 +287,7 @@ export function FlashcardPracticeArea({
     );
   }
 
-  // Show deck selection if not selected
+  // Deck list
   if (!selectedDeck) {
     return (
       <div className="flex w-full flex-1 items-center justify-center">
@@ -504,7 +330,6 @@ export function FlashcardPracticeArea({
             </div>
           ) : (
             <div className="px-4 pb-5">
-              {/* Confirmation modal for delete */}
               {confirmDeleteDeck && (
                 <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
                   <div className="w-full max-w-md rounded-lg bg-[#30302e] p-6 shadow-lg">
@@ -513,7 +338,7 @@ export function FlashcardPracticeArea({
                     </h3>
                     <p className="mb-4 text-sm text-gray-300">
                       Are you sure you want to delete &quot;
-                      {confirmDeleteDeck.fc_name}&quot; and all its cards? This
+                      {confirmDeleteDeck.name}&quot; and all its cards? This
                       action cannot be undone.
                     </p>
                     <div className="flex justify-end gap-2">
@@ -539,105 +364,85 @@ export function FlashcardPracticeArea({
               )}
               <div className="mb-6 flex items-center justify-between">
                 <h2 className="text-xl text-white">Select a Deck</h2>
-                <div className="flex justify-end">
-                  <DropdownMenu>
-                    <DropdownMenuTrigger asChild>
-                      <Button
-                        variant="ghost"
-                        className="border border-[#4a4a46] bg-[#191919] text-sm text-gray-300 hover:bg-[#4a4a46] hover:text-white"
-                      >
-                        Sort by:{' '}
-                        {sortBy === 'name'
-                          ? 'Name'
-                          : sortBy === 'due'
-                            ? 'Due Cards'
-                            : 'Progress'}
-                        <svg
-                          className="ml-2 h-4 w-4"
-                          fill="none"
-                          stroke="currentColor"
-                          viewBox="0 0 24 24"
-                        >
-                          <path
-                            strokeLinecap="round"
-                            strokeLinejoin="round"
-                            strokeWidth={2}
-                            d="M19 9l-7 7-7-7"
-                          />
-                        </svg>
-                      </Button>
-                    </DropdownMenuTrigger>
-                    <DropdownMenuContent
-                      align="end"
-                      className="w-40 border-[#4a4a46] bg-[#30302e]"
+                <DropdownMenu>
+                  <DropdownMenuTrigger asChild>
+                    <Button
+                      variant="ghost"
+                      className="border border-[#4a4a46] bg-[#191919] text-sm text-gray-300 hover:bg-[#4a4a46] hover:text-white"
                     >
-                      <DropdownMenuItem
-                        onClick={() => setSortBy('name')}
-                        className="cursor-pointer text-gray-300 focus:bg-[#4a4a46] focus:text-white"
+                      Sort by:{' '}
+                      {sortBy === 'name'
+                        ? 'Name'
+                        : sortBy === 'due'
+                          ? 'Due Cards'
+                          : 'Progress'}
+                      <svg
+                        className="ml-2 h-4 w-4"
+                        fill="none"
+                        stroke="currentColor"
+                        viewBox="0 0 24 24"
                       >
-                        Name
-                      </DropdownMenuItem>
-                      <DropdownMenuItem
-                        onClick={() => setSortBy('due')}
-                        className="cursor-pointer text-gray-300 focus:bg-[#4a4a46] focus:text-white"
-                      >
-                        Due Cards
-                      </DropdownMenuItem>
-                      <DropdownMenuItem
-                        onClick={() => setSortBy('progress')}
-                        className="cursor-pointer text-gray-300 focus:bg-[#4a4a46] focus:text-white"
-                      >
-                        Progress
-                      </DropdownMenuItem>
-                    </DropdownMenuContent>
-                  </DropdownMenu>
-                </div>
+                        <path
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          strokeWidth={2}
+                          d="M19 9l-7 7-7-7"
+                        />
+                      </svg>
+                    </Button>
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent
+                    align="end"
+                    className="w-40 border-[#4a4a46] bg-[#30302e]"
+                  >
+                    <DropdownMenuItem
+                      onClick={() => setSortBy('name')}
+                      className="cursor-pointer text-gray-300 focus:bg-[#4a4a46] focus:text-white"
+                    >
+                      Name
+                    </DropdownMenuItem>
+                    <DropdownMenuItem
+                      onClick={() => setSortBy('due')}
+                      className="cursor-pointer text-gray-300 focus:bg-[#4a4a46] focus:text-white"
+                    >
+                      Due Cards
+                    </DropdownMenuItem>
+                    <DropdownMenuItem
+                      onClick={() => setSortBy('progress')}
+                      className="cursor-pointer text-gray-300 focus:bg-[#4a4a46] focus:text-white"
+                    >
+                      Progress
+                    </DropdownMenuItem>
+                  </DropdownMenuContent>
+                </DropdownMenu>
               </div>
               <div className="grid max-w-3xl grid-cols-1 gap-3 md:grid-cols-2">
                 {decks
                   .slice()
                   .sort((a, b) => {
-                    const statsA = deckStats[a.fc_id];
-                    const statsB = deckStats[b.fc_id];
-
-                    if (sortBy === 'name') {
-                      return a.fc_name.localeCompare(b.fc_name);
-                    } else if (sortBy === 'due') {
-                      const dueA = statsA?.dueCards || 0;
-                      const dueB = statsB?.dueCards || 0;
-                      return dueB - dueA;
-                    } else if (sortBy === 'progress') {
-                      const progressA = statsA
-                        ? statsA.totalCards > 0
-                          ? ((statsA.totalCards - statsA.dueCards) /
-                              statsA.totalCards) *
-                            100
-                          : 0
+                    if (sortBy === 'name') return a.name.localeCompare(b.name);
+                    if (sortBy === 'due') return b.dueCards - a.dueCards;
+                    const progressA =
+                      a.totalCards > 0
+                        ? ((a.totalCards - a.dueCards) / a.totalCards) * 100
                         : 0;
-                      const progressB = statsB
-                        ? statsB.totalCards > 0
-                          ? ((statsB.totalCards - statsB.dueCards) /
-                              statsB.totalCards) *
-                            100
-                          : 0
+                    const progressB =
+                      b.totalCards > 0
+                        ? ((b.totalCards - b.dueCards) / b.totalCards) * 100
                         : 0;
-                      return progressB - progressA;
-                    }
-                    return 0;
+                    return progressB - progressA;
                   })
                   .map((deck, index) => {
-                    const stats = deckStats[deck.fc_id];
-                    const progress = stats
-                      ? stats.totalCards > 0
-                        ? ((stats.totalCards - stats.dueCards) /
-                            stats.totalCards) *
+                    const progress =
+                      deck.totalCards > 0
+                        ? ((deck.totalCards - deck.dueCards) /
+                            deck.totalCards) *
                           100
-                        : 0
-                      : 0;
+                        : 0;
 
                     return (
                       <Card
-                        key={deck.fc_id}
+                        key={deck.id}
                         onClick={() => selectDeck(deck)}
                         className="group cursor-pointer border border-[#4a4a46] bg-[#3a3a38] p-4 transition-all duration-200 hover:border-[#5a5a56] hover:bg-[#4a4a46] hover:shadow-lg"
                       >
@@ -648,7 +453,7 @@ export function FlashcardPracticeArea({
                                 {index + 1}
                               </span>
                               <h3 className="font-semibold text-white group-hover:underline">
-                                {deck.fc_name}
+                                {deck.name}
                               </h3>
                             </div>
                             {deck.description && (
@@ -657,7 +462,6 @@ export function FlashcardPracticeArea({
                               </p>
                             )}
                           </div>
-                          {/* Triple dot menu for deck actions */}
                           <DropdownMenu>
                             <DropdownMenuTrigger asChild>
                               <button
@@ -686,11 +490,7 @@ export function FlashcardPracticeArea({
                               <DropdownMenuItem
                                 onClick={(e) => {
                                   e.stopPropagation();
-                                  if (onRequestEditDeck) {
-                                    onRequestEditDeck(deck);
-                                  } else {
-                                    alert('Edit deck not available');
-                                  }
+                                  onRequestEditDeck?.(deck);
                                 }}
                                 className="cursor-pointer text-gray-300 focus:bg-[#4a4a46] focus:text-white"
                               >
@@ -713,13 +513,13 @@ export function FlashcardPracticeArea({
                           <div className="flex items-center justify-between text-sm">
                             <span className="text-gray-400">Due</span>
                             <span className="font-semibold text-white">
-                              {stats?.dueCards || 0}
+                              {deck.dueCards}
                             </span>
                           </div>
                           <div className="flex items-center justify-between pb-4 text-sm">
                             <span className="text-gray-400">Total</span>
                             <span className="font-semibold text-white">
-                              {stats?.totalCards || 0}
+                              {deck.totalCards}
                             </span>
                           </div>
                           <div>
@@ -745,7 +545,8 @@ export function FlashcardPracticeArea({
     );
   }
 
-  if (!currentCardState || !currentQuestion) {
+  // Loading session
+  if (isLoadingSession) {
     return (
       <div className="flex w-full flex-1 items-center justify-center">
         <div className="rounded-lg border border-[#4a4a46] bg-[#30302e] p-6">
@@ -755,11 +556,61 @@ export function FlashcardPracticeArea({
     );
   }
 
-  if (allMastered) {
-    const nextCard = cardStates.reduce((min: CardState, card: CardState) =>
-      card.nextReviewAt < min.nextReviewAt ? card : min
+  // No cards currently due (session loaded with 0 cards)
+  if (noCardsDue) {
+    const nextDate = nextDueAt();
+
+    return (
+      <div className="flex w-full flex-1 items-center justify-center">
+        <div className="w-full max-w-md rounded-lg border border-[#4a4a46] bg-[#30302e] p-6">
+          <div className="mb-8">
+            <div className="mb-4 flex items-start justify-between">
+              <h2 className="text-2xl font-bold text-white">No Cards Due</h2>
+              <button
+                onClick={handleOptionalStop}
+                className="flex h-8 w-8 items-center justify-center rounded-full border border-[#4a4a46] text-gray-400 transition-colors hover:border-[#5a5a56] hover:bg-[#4a4a46] hover:text-white"
+                aria-label="Back to decks"
+              >
+                <ArrowLeft className="h-4 w-4" />
+              </button>
+            </div>
+            <p className="mb-6 text-base text-gray-300">
+              All cards in this deck have been scheduled for a future review.
+            </p>
+            {nextDate ? (
+              <p className="mb-8 text-gray-400">
+                Next card available at:
+                <br />
+                <span className="text-lg font-semibold text-white">
+                  {nextDate.toLocaleString()}
+                </span>
+              </p>
+            ) : (
+              <p className="mb-8 text-gray-400">
+                Check back later for your next review.
+              </p>
+            )}
+            <p className="text-sm text-gray-400">
+              Deck: <span className="text-gray-300">{selectedDeck?.name}</span>
+            </p>
+          </div>
+          <div className="flex justify-end">
+            <Button
+              onClick={handleOptionalStop}
+              variant="default"
+              className="px-8 py-2 text-sm"
+            >
+              Back to Decks
+            </Button>
+          </div>
+        </div>
+      </div>
     );
-    const nextDueTime = new Date(nextCard.nextReviewAt).toLocaleString();
+  }
+
+  // Session complete (user reviewed all cards in this session)
+  if (sessionComplete) {
+    const nextDate = nextDueAt();
 
     return (
       <div className="flex w-full flex-1 items-center justify-center">
@@ -780,36 +631,39 @@ export function FlashcardPracticeArea({
             <p className="mb-6 text-base text-gray-300">
               No more cards due for review.
             </p>
-            <p className="mb-8 text-gray-400">
-              Next card available at:
-              <br />
-              <span className="text-lg font-semibold text-white">
-                {nextDueTime}
-              </span>
-            </p>
+            {nextDate && (
+              <p className="mb-8 text-gray-400">
+                Next card available at:
+                <br />
+                <span className="text-lg font-semibold text-white">
+                  {nextDate.toLocaleString()}
+                </span>
+              </p>
+            )}
             <p className="text-sm text-gray-400">
-              Deck:{' '}
-              <span className="text-gray-300">{selectedDeck?.fc_name}</span>
+              Deck: <span className="text-gray-300">{selectedDeck?.name}</span>
             </p>
           </div>
-          <div className="flex flex-row justify-between">
+          <div className="flex justify-end">
             <Button
-              onClick={resetDeckProgress}
-              variant="ghost"
-              className="border border-[#4a4a46] px-4 py-2 text-sm text-gray-400 transition-colors hover:border-[#5a5a56] hover:bg-[#4a4a46] hover:text-white"
-              disabled={isResetting}
-            >
-              {isResetting ? 'Resetting...' : 'Reset Progress'}
-            </Button>
-
-            <Button
-              disabled
+              onClick={handleOptionalStop}
               variant="default"
-              className="cursor-not-allowed border border-[#4a4a46] bg-[#191919] px-4 py-2 text-sm text-gray-500 opacity-50"
+              className="px-8 py-2 text-sm"
             >
-              Start
+              Done
             </Button>
           </div>
+        </div>
+      </div>
+    );
+  }
+
+  // Active card review
+  if (!currentCard) {
+    return (
+      <div className="flex w-full flex-1 items-center justify-center">
+        <div className="rounded-lg border border-[#4a4a46] bg-[#30302e] p-6">
+          <LoadingSpinner />
         </div>
       </div>
     );
@@ -823,7 +677,7 @@ export function FlashcardPracticeArea({
           <div className="mb-6 flex items-center justify-between">
             <div>
               <h2 className="mb-1 text-2xl font-bold text-white">Flashcards</h2>
-              <p className="text-gray-400">{selectedDeck?.fc_name}</p>
+              <p className="text-gray-400">{selectedDeck?.name}</p>
             </div>
             <button
               onClick={handleOptionalStop}
@@ -846,42 +700,30 @@ export function FlashcardPracticeArea({
             </button>
           </div>
           <div className="mb-6 flex gap-6 text-sm">
-            <div className="relative">
+            <div>
               <span className="text-gray-400">Due:</span>
               <span
                 className={`ml-2 font-semibold text-white transition-all duration-300 ${
                   dueCountAnimation === 'subtract'
                     ? 'scale-90 text-red-400'
-                    : dueCountAnimation === 'add'
-                      ? 'scale-110 text-green-400'
-                      : ''
+                    : ''
                 }`}
               >
-                {dueCards.length}
+                {dueCount}
               </span>
             </div>
             <div>
               <span className="text-gray-400">Total:</span>
               <span className="ml-2 font-semibold text-white">
-                {cardStates.length}
+                {totalCards}
               </span>
             </div>
           </div>
         </div>
 
-        {/* Error message */}
         {error && (
           <div className="mb-6 rounded-lg border border-red-500/50 bg-red-900/20 p-4 text-center">
             <p className="text-red-300">{error}</p>
-          </div>
-        )}
-
-        {/* Show message when session due cards are done */}
-        {showMasteredMessage && (
-          <div className="mb-6 rounded-lg border border-[#4a4a46] bg-[#191919] p-4 text-center">
-            <p className="text-gray-300">
-              All current due cards reviewed! You can continue or stop here.
-            </p>
           </div>
         )}
 
@@ -902,7 +744,7 @@ export function FlashcardPracticeArea({
                       Question
                     </p>
                     <p className="text-xl font-medium text-white">
-                      {currentQuestion.question}
+                      {currentCard.front}
                     </p>
                   </>
                 ) : (
@@ -911,7 +753,7 @@ export function FlashcardPracticeArea({
                       Answer
                     </p>
                     <p className="text-xl font-medium text-white">
-                      {currentQuestion.answer}
+                      {currentCard.back}
                     </p>
                   </>
                 )}
@@ -925,15 +767,17 @@ export function FlashcardPracticeArea({
               <div className="grid grid-cols-2 gap-2">
                 <Button
                   onClick={() => handleDifficulty('again')}
+                  disabled={isSubmitting}
                   variant="ghost"
-                  className="flex items-center justify-center border border-red-500/50 bg-red-900/20 py-3 text-sm font-semibold text-red-400 hover:bg-red-900/40 hover:text-red-300"
+                  className="flex items-center justify-center border border-red-500/50 bg-red-900/20 py-3 text-sm font-semibold text-red-400 hover:bg-red-900/40 hover:text-red-300 disabled:opacity-50"
                 >
                   Again
                 </Button>
                 <Button
                   onClick={() => handleDifficulty('hard')}
+                  disabled={isSubmitting}
                   variant="ghost"
-                  className="flex items-center justify-center border border-orange-500/50 bg-orange-900/20 py-3 text-sm font-semibold text-orange-400 hover:bg-orange-900/40 hover:text-orange-300"
+                  className="flex items-center justify-center border border-orange-500/50 bg-orange-900/20 py-3 text-sm font-semibold text-orange-400 hover:bg-orange-900/40 hover:text-orange-300 disabled:opacity-50"
                 >
                   Hard
                 </Button>
@@ -941,31 +785,22 @@ export function FlashcardPracticeArea({
               <div className="grid grid-cols-2 gap-2">
                 <Button
                   onClick={() => handleDifficulty('medium')}
+                  disabled={isSubmitting}
                   variant="ghost"
-                  className="flex items-center justify-center border border-blue-500/50 bg-blue-900/20 py-3 text-sm font-semibold text-blue-400 hover:bg-blue-900/40 hover:text-blue-300"
+                  className="flex items-center justify-center border border-blue-500/50 bg-blue-900/20 py-3 text-sm font-semibold text-blue-400 hover:bg-blue-900/40 hover:text-blue-300 disabled:opacity-50"
                 >
                   Medium
                 </Button>
                 <Button
                   onClick={() => handleDifficulty('easy')}
+                  disabled={isSubmitting}
                   variant="ghost"
-                  className="flex items-center justify-center border border-green-500/50 bg-green-900/20 py-3 text-sm font-semibold text-green-400 hover:bg-green-900/40 hover:text-green-300"
+                  className="flex items-center justify-center border border-green-500/50 bg-green-900/20 py-3 text-sm font-semibold text-green-400 hover:bg-green-900/40 hover:text-green-300 disabled:opacity-50"
                 >
                   Easy
                 </Button>
               </div>
             </div>
-          )}
-
-          {/* Optional Stop Button */}
-          {!isFlipped && dueCards.length === 0 && !allMastered && (
-            <Button
-              onClick={handleOptionalStop}
-              variant="ghost"
-              className="mt-6 w-full border border-[#4a4a46] bg-[#191919] py-2 text-sm text-gray-400 hover:bg-[#4a4a46] hover:text-white"
-            >
-              Optional Stop
-            </Button>
           )}
         </div>
       </div>

--- a/src/components/upload/UploadContent.tsx
+++ b/src/components/upload/UploadContent.tsx
@@ -14,6 +14,7 @@ import { FeatureFooterCard } from '@/components/FeatureFooterCard';
 import { Icon } from '@iconify/react';
 import { Upload, FileText, CheckCircle2, XCircle, Loader2 } from 'lucide-react';
 import { createFlashcardDeck } from '@/lib/frontend-store';
+import { fsrsClient } from '@/lib/fsrs-client';
 
 const supportedTypes = [
   {
@@ -76,6 +77,7 @@ function buildFlashcardsFromText(text: string, count = 10) {
 
 export function UploadContent() {
   const [file, setFile] = useState<File | null>(null);
+  const [rawFile, setRawFile] = useState<File | null>(null);
   const [uploadedFile, setUploadedFile] = useState<UploadedFile | null>(null);
   const [uploading, setUploading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -151,6 +153,7 @@ export function UploadContent() {
       const publicUrl = URL.createObjectURL(file);
       const extractedText = file.type === 'text/plain' ? await file.text() : '';
 
+      setRawFile(file);
       setUploadedFile({
         fileName: file.name,
         fileSize: file.size,
@@ -168,39 +171,47 @@ export function UploadContent() {
   };
 
   const handleGenerateCards = async () => {
-    if (!uploadedFile) return;
-
-    // Check if we have extracted text
-    if (!uploadedFile.extractedText) {
-      setError('No text content available to generate flashcards');
-      return;
-    }
+    if (!uploadedFile || !rawFile) return;
 
     setError(null);
     setSuccess(null);
+    setUploading(true);
 
     try {
-      const flashcards = buildFlashcardsFromText(
-        uploadedFile.extractedText,
-        10
-      );
-      if (flashcards.length === 0) {
-        throw new Error('Could not derive any flashcards from this file');
+      if (rawFile.type === 'application/pdf') {
+        const formData = new FormData();
+        formData.append('pdf', rawFile);
+        formData.append('cardCount', '10');
+        const result = await fsrsClient.decks.create(formData);
+        setSuccess(
+          `Created deck "${result.deck.name}" with ${result.cards.length} AI-generated cards.`
+        );
+      } else {
+        if (!uploadedFile.extractedText) {
+          throw new Error('No text content available to generate flashcards');
+        }
+        const flashcards = buildFlashcardsFromText(
+          uploadedFile.extractedText,
+          10
+        );
+        if (flashcards.length === 0) {
+          throw new Error('Could not derive any flashcards from this file');
+        }
+        const deck = createFlashcardDeck({
+          deckTitle: uploadedFile.fileName.replace(/\.[^/.]+$/, ''),
+          description: `Generated from ${uploadedFile.fileName}`,
+          flashcards,
+        });
+        setSuccess(
+          `Saved ${flashcards.length} flashcards in deck "${deck.fc_name}".`
+        );
       }
-
-      const deck = createFlashcardDeck({
-        deckTitle: uploadedFile.fileName.replace(/\.[^/.]+$/, ''),
-        description: `Generated locally from ${uploadedFile.fileName}`,
-        flashcards,
-      });
-
-      setSuccess(
-        `Saved ${flashcards.length} local flashcards in deck "${deck.fc_name}".`
-      );
     } catch (err) {
       setError(
         err instanceof Error ? err.message : 'Failed to generate flashcards'
       );
+    } finally {
+      setUploading(false);
     }
   };
 

--- a/src/hooks/useDecks.ts
+++ b/src/hooks/useDecks.ts
@@ -1,0 +1,94 @@
+'use client';
+
+import { useState, useCallback, useEffect, useMemo } from 'react';
+import { fsrsClient } from '@/lib/fsrs-client';
+import type { Deck, Card } from '@/types/fsrs';
+
+interface RawDeckEntry {
+  deck: Deck;
+  cards: Card[];
+}
+
+export interface DeckWithStats extends Deck {
+  totalCards: number;
+  dueCards: number;
+  nextDueAt: Date | null;
+}
+
+export function useDecks() {
+  const [rawDecks, setRawDecks] = useState<RawDeckEntry[]>([]);
+  const [now, setNow] = useState(() => new Date());
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Derive stats purely from stored card data + current time — no API call needed
+  const decks: DeckWithStats[] = useMemo(
+    () =>
+      rawDecks.map(({ deck, cards }) => {
+        const dueCards = cards.filter((c) => new Date(c.due) <= now).length;
+        const upcoming = cards
+          .map((c) => new Date(c.due))
+          .filter((d) => d > now)
+          .sort((a, b) => a.getTime() - b.getTime());
+        return {
+          ...deck,
+          totalCards: cards.length,
+          dueCards,
+          nextDueAt: upcoming[0] ?? null,
+        };
+      }),
+    [rawDecks, now]
+  );
+
+  // Advance the clock exactly when the next card across any deck becomes due
+  useEffect(() => {
+    const nearest =
+      decks
+        .map((d) => d.nextDueAt)
+        .filter((d): d is Date => d !== null)
+        .sort((a, b) => a.getTime() - b.getTime())[0] ?? null;
+
+    if (!nearest) return;
+
+    const delay = nearest.getTime() - Date.now();
+    if (delay <= 0) {
+      setNow(new Date());
+      return;
+    }
+
+    const timer = setTimeout(() => setNow(new Date()), delay);
+    return () => clearTimeout(timer);
+  }, [decks]);
+
+  const fetchDecks = useCallback(async () => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      const deckList = await fsrsClient.decks.list();
+      const entries = await Promise.all(
+        deckList.map(async (deck) => ({
+          deck,
+          cards: await fsrsClient.cards.list(deck.id),
+        }))
+      );
+      setRawDecks(entries);
+      setNow(new Date());
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load decks');
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  const deleteDeck = useCallback(async (deckId: number) => {
+    await fsrsClient.decks.delete(deckId);
+    setRawDecks((prev) => prev.filter((e) => e.deck.id !== deckId));
+  }, []);
+
+  const createDeck = useCallback(
+    async (formData: FormData) => fsrsClient.decks.create(formData),
+    []
+  );
+
+  return { decks, isLoading, error, fetchDecks, deleteDeck, createDeck };
+}

--- a/src/hooks/useSession.ts
+++ b/src/hooks/useSession.ts
@@ -1,0 +1,120 @@
+'use client';
+
+import { useState, useCallback } from 'react';
+import { fsrsClient } from '@/lib/fsrs-client';
+import type { Card, Review, SessionCard } from '@/types/fsrs';
+import type { Difficulty } from '@/components/pomodoro/spacedRepetition';
+
+const DIFFICULTY_TO_GRADE: Record<Difficulty, 1 | 2 | 3 | 4> = {
+  again: 1,
+  hard: 2,
+  medium: 3,
+  easy: 4,
+};
+
+export function useSession(deckId: number | null) {
+  const [sessionCards, setSessionCards] = useState<SessionCard[]>([]);
+  const [allCards, setAllCards] = useState<Card[]>([]);
+  const [currentIndex, setCurrentIndex] = useState(0);
+  const [isLoading, setIsLoading] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [sessionComplete, setSessionComplete] = useState(false);
+  const [noCardsDue, setNoCardsDue] = useState(false);
+
+  const loadSession = useCallback(async () => {
+    if (deckId === null) return;
+    setIsLoading(true);
+    setError(null);
+    setSessionComplete(false);
+    setNoCardsDue(false);
+    setCurrentIndex(0);
+    try {
+      const [sessionData, cards] = await Promise.all([
+        fsrsClient.sessions.load(deckId),
+        fsrsClient.cards.list(deckId),
+      ]);
+      setSessionCards(sessionData.cards);
+      setAllCards(cards);
+      if (sessionData.cards.length === 0) {
+        setNoCardsDue(true);
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load session');
+    } finally {
+      setIsLoading(false);
+    }
+  }, [deckId]);
+
+  const submitReview = useCallback(
+    async (difficulty: Difficulty) => {
+      if (deckId === null) return;
+      const card = sessionCards[currentIndex];
+      if (!card) return;
+
+      const review: Review = {
+        cardId: card.id,
+        rating: DIFFICULTY_TO_GRADE[difficulty],
+        reviewedAt: new Date().toISOString(),
+      };
+
+      setIsSubmitting(true);
+      try {
+        await fsrsClient.sessions.submit(deckId, [review]);
+        const remaining = sessionCards.filter((_, i) => i !== currentIndex);
+        setSessionCards(remaining);
+        setCurrentIndex(
+          Math.max(0, Math.min(currentIndex, remaining.length - 1))
+        );
+
+        if (remaining.length === 0) {
+          const cards = await fsrsClient.cards.list(deckId);
+          setAllCards(cards);
+          setSessionComplete(true);
+        }
+      } catch (err) {
+        setError(
+          err instanceof Error ? err.message : 'Failed to submit review'
+        );
+      } finally {
+        setIsSubmitting(false);
+      }
+    },
+    [deckId, sessionCards, currentIndex]
+  );
+
+  const nextDueAt = useCallback((): Date | null => {
+    if (allCards.length === 0) return null;
+    const now = new Date();
+    const futureDates = allCards
+      .map((c) => new Date(c.due))
+      .filter((d) => d > now)
+      .sort((a, b) => a.getTime() - b.getTime());
+    return futureDates[0] ?? null;
+  }, [allCards]);
+
+  const resetSession = useCallback(() => {
+    setSessionCards([]);
+    setAllCards([]);
+    setCurrentIndex(0);
+    setError(null);
+    setSessionComplete(false);
+    setNoCardsDue(false);
+  }, []);
+
+  return {
+    sessionCards,
+    currentCard: sessionCards[currentIndex] ?? null,
+    totalCards: allCards.length,
+    dueCount: sessionCards.length,
+    isLoading,
+    isSubmitting,
+    error,
+    sessionComplete,
+    noCardsDue,
+    loadSession,
+    submitReview,
+    nextDueAt,
+    resetSession,
+  };
+}

--- a/src/lib/fsrs-client.ts
+++ b/src/lib/fsrs-client.ts
@@ -1,0 +1,66 @@
+import type { Card, Deck, Review, SessionCard } from '@/types/fsrs';
+
+const BASE_URL = process.env.NEXT_PUBLIC_BACKEND_URL ?? 'http://localhost:8000';
+
+async function request<T>(path: string, options?: RequestInit): Promise<T> {
+  const isFormData = options?.body instanceof FormData;
+  const res = await fetch(`${BASE_URL}${path}`, {
+    ...options,
+    credentials: 'include',
+    headers: {
+      ...(!isFormData ? { 'Content-Type': 'application/json' } : {}),
+      ...options?.headers,
+    },
+  });
+
+  if (!res.ok) {
+    const body = (await res.json().catch(() => ({}))) as Record<string, string>;
+    throw new Error(body.error ?? body.message ?? `HTTP ${res.status}`);
+  }
+
+  if (res.status === 204) return undefined as T;
+  return res.json() as Promise<T>;
+}
+
+export const fsrsClient = {
+  decks: {
+    list: (): Promise<Deck[]> => request('/decks'),
+    create: (formData: FormData): Promise<{ deck: Deck; cards: Card[] }> =>
+      request('/decks', { method: 'POST', body: formData }),
+    get: (id: number): Promise<Deck> => request(`/decks/${id}`),
+    delete: (id: number): Promise<void> =>
+      request(`/decks/${id}`, { method: 'DELETE' }),
+  },
+
+  cards: {
+    list: (deckId: number): Promise<Card[]> =>
+      request(`/decks/${deckId}/cards`),
+    add: (deckId: number, front: string, back: string): Promise<Card> =>
+      request(`/decks/${deckId}/cards`, {
+        method: 'POST',
+        body: JSON.stringify({ front, back }),
+      }),
+    update: (
+      deckId: number,
+      cardId: number,
+      front: string,
+      back: string
+    ): Promise<Card> =>
+      request(`/decks/${deckId}/cards/${cardId}`, {
+        method: 'PUT',
+        body: JSON.stringify({ front, back }),
+      }),
+    delete: (deckId: number, cardId: number): Promise<void> =>
+      request(`/decks/${deckId}/cards/${cardId}`, { method: 'DELETE' }),
+  },
+
+  sessions: {
+    load: (deckId: number): Promise<{ cards: SessionCard[] }> =>
+      request(`/decks/${deckId}/session`),
+    submit: (deckId: number, reviews: Review[]): Promise<{ saved: number }> =>
+      request(`/decks/${deckId}/session`, {
+        method: 'POST',
+        body: JSON.stringify({ reviews }),
+      }),
+  },
+};

--- a/src/types/fsrs.ts
+++ b/src/types/fsrs.ts
@@ -1,0 +1,42 @@
+export interface Deck {
+  id: number;
+  user_id: string;
+  name: string;
+  description: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface Card {
+  id: number;
+  deck_id: number;
+  front: string;
+  back: string;
+  due: string;
+  stability: number;
+  difficulty: number;
+  scheduled_days: number;
+  reps: number;
+  lapses: number;
+  state: number;
+  last_review: string | null;
+}
+
+export interface SessionCard {
+  id: number;
+  front: string;
+  back: string;
+  state: number;
+  intervals: {
+    again: string;
+    hard: string;
+    good: string;
+    easy: string;
+  };
+}
+
+export interface Review {
+  cardId: number;
+  rating: 1 | 2 | 3 | 4;
+  reviewedAt: string;
+}


### PR DESCRIPTION
New files:
- src/types/fsrs.ts: Deck, Card, SessionCard, Review types (aligned with backend schema)
- src/lib/fsrs-client.ts: fsrsClient for /decks, /decks/:id/cards, /decks/:id/session
- src/hooks/useDecks.ts: fetches decks + cards, derives dueCards via useMemo with a local clock that advances only when the next card becomes due (no polling/flicker)
- src/hooks/useSession.ts: loads FSRS session, submits reviews, distinguishes noCardsDue (0 cards on load) from sessionComplete (user finished reviewing)

Modified:
- FlashcardPracticeArea.tsx: rewritten to use useDecks + useSession, removed SM-2 and localStorage; FSRS grades again=1 hard=2 medium=3 easy=4; added noCardsDue screen; visibilitychange refreshes deck list; auto-reloads session when due
- UploadContent.tsx: PDFs sent to POST /decks for Gemini AI generation; TXT files retain local extraction fallback
- PomodoroContent.tsx: openEditDeck accepts DeckWithStats, fetches cards via fsrsClient; editPayload uses apiDeckId
- AddFlashcardsWidget.tsx: added apiDeckId prop + backendId on entries; edit mode saves via fsrsClient.cards.update/add/delete

Removed:
- src/types/api.ts: replaced by src/types/fsrs.ts
- src/lib/api-client.ts: replaced by src/lib/fsrs-client.ts

Backend migration:
- 20260514000001_fix_timestamp_timezone.sql: cards.due, cards.last_review, review_logs.due, review_logs.review changed TIMESTAMP to TIMESTAMPTZ to fix client/server timezone mismatch causing session to return 0 due cards